### PR TITLE
Extract script for import

### DIFF
--- a/fetch-element.html
+++ b/fetch-element.html
@@ -3,14 +3,7 @@
 Copyright (c) 2015 Glenn Vandeuren. All rights reserved.
 -->
 <link rel="import" href="../polymer/polymer.html">
-<script>
-  if (!Promise) {
-    document.write('<script src="../es6-promise/dist/es6-promise.js"><\\/script>');
-  }
-  if (!fetch) {
-    document.write('<script src="../fetch/fetch.js"><\\/script>');
-  }
-</script>
+<link rel="import" href="fetch-import.html">
 
 <!--
 An element wrapping [Fetch](https://github.com/github/fetch).

--- a/fetch-import.html
+++ b/fetch-import.html
@@ -1,0 +1,8 @@
+<script>
+  if (!Promise) {
+    document.write('<script src="../es6-promise/dist/es6-promise.js"><\\/script>');
+  }
+  if (!fetch) {
+    document.write('<script src="../fetch/fetch.js"><\\/script>');
+  }
+</script>

--- a/fetch-import.html
+++ b/fetch-import.html
@@ -2,7 +2,5 @@
   if (!Promise) {
     document.write('<script src="../es6-promise/dist/es6-promise.js"><\\/script>');
   }
-  if (!fetch) {
-    document.write('<script src="../fetch/fetch.js"><\\/script>');
-  }
 </script>
+<script src="../fetch/fetch.js"></script>


### PR DESCRIPTION
These two commits make it easier to consume just the library. I didn't want to create a new "fetch-import-element" for that purpose, as it just nicely fits in here.

Basically instead of having a lot of `<script src="...fetch.js">` in many elements, one now can use `<link rel="import" href="fetch-import.html">`. The browser will automatically only load the import once, but it would load the script variant every time it occurs, which blows up the size of the web application.
